### PR TITLE
Fix fan speed read

### DIFF
--- a/device/common/pddf/plugins/fanutil.py
+++ b/device/common/pddf/plugins/fanutil.py
@@ -155,7 +155,7 @@ class FanUtil(FanBase):
             if val.isalpha():
                 frpm = 0
             else:
-                frpm = int(val)
+                frpm = int(float(val))
 
             ret += "FAN-%d\t\t\t%d\n" % (i, frpm)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Reading fan speed can lead to the following Error:

```
ERR pmon#thermalctld: Failed to read from file /var/run/hw-management/thermal/fan1_speed_get - ValueError("invalid literal for int() with base 10: ''")
```

The error message means that the string provided to int could not be parsed as an integer.

In order to avoid from it, "float" need to be used according to the following example: 

`int(float('55063.000000'))`


```
    def get_speed(self, idx):
        # 1 based fan index 
        if idx < 1 or idx > self.num_fans: 
            print("Invalid fan index %d\n" % idx)
            return 0

        attr = "fan" + str(idx) + "_input"
        output = pddf_obj.get_attr_name_output("FAN-CTRL", attr)
        if not output:
            return 0

        #mode = output['mode']
        val = output['status'].rstrip()

        if val.isalpha():
            return 0
        else:
            rpm_speed = int(float(val))

        return rpm_speed

    def get_speeds(self):
        num_fan = self.get_num_fan()
        ret = "FAN_INDEX\t\tRPM\n"

        for i in range(1, num_fan+1):
            attr1 = "fan" + str(i) + "_input"
            output = pddf_obj.get_attr_name_output("FAN-CTRL", attr1)
            if not output:
                return ""

            #mode = output['mode']
            val = output['status'].rstrip()

            if val.isalpha():
                frpm = 0
            else:
                frpm = int(val)

            ret += "FAN-%d\t\t\t%d\n" % (i, frpm)

        return ret

```

While the code at `def get_speed(self, idx):` is protected, the code in `def get_speeds(self):` is not. 
So the fix should be to change `frpm = int(val)` into `frpm = int(float(val))` in this API


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add float(val)

#### How to verify it

Run sonic-mgmt tests 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

