### PR TITLE
Add BMC CLIs and fix yang model

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -1113,7 +1113,6 @@ class Chassis(ChassisBase):
         self._bmc_initialized = True
 
     def _initialize_bmc(self):
-        # TODO(BMC): check why hw-management/config/cpld_num created after 6m
         self.initialize_components()
         self.initialize_bmc()
 

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -319,6 +319,33 @@ module sonic-device_metadata {
                 }
             }
             /* end of container localhost */
+
+            container bmc {
+                description "BMC configuration information";
+
+                leaf bmc_if_name {
+                    type string {
+                        length 1..64;
+                    }
+                    description "BMC interface name";
+                }
+
+                leaf bmc_if_addr {
+                    type inet:ipv4-address;
+                    description "BMC interface IP address";
+                }
+
+                leaf bmc_addr {
+                    type inet:ipv4-address;
+                    description "BMC IP address";
+                }
+
+                leaf bmc_net_mask {
+                    type inet:ipv4-address;
+                    description "BMC network mask";
+                }
+            }
+            /* end of container bmc */
         }
         /* end of container DEVICE_METADATA */
     }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

