### PR TITLE
feat(bmc): UT

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -958,78 +958,7 @@ class ComponentBMCObj(Component):
             return (False, (error_msg, updated))
 
     def get_firmware_version(self):
-        ret = 0
-        version = 'N/A'
-        try:
-            ret, version =  self.bmc.get_firmware_version(self.get_firmware_id())
-        except Exception as e:
-            return 'N/A'
-        if (ret != 0):
-            return 'N/A'
-        return version
-
-    def get_eeprom_info(self):
-        eeprom_id = self.get_eeprom_id()
-        if eeprom_id is None:
-            print(" Can't read eeprom. Missing eeprom id.")
-            return {}
-        ret, eeprom_info = self.bmc.get_eeprom_info(eeprom_id)
-        if ret != 0:
-            print(f'Fail to get {eeprom_id} from BMC, error code: {ret}')
-        return eeprom_info
-
-    def _is_bmc_eeprom_content_valid(self, eeprom_info):
-        if None == eeprom_info or 0 == len(eeprom_info):
-            print(f'Got empty eeprom info: {eeprom_info}')
-            return False
-        got_error = eeprom_info.get('error')
-
-        if got_error:
-            print(f'Got error when quering eeprom: {got_error}')
-            return False
-        eeprom_error_code = eeprom_info.get('Error_code','ok')
-        eeprom_health = eeprom_info.get('Health','ok')
-
-        if eeprom_error_code.lower() != 'ok' or eeprom_health.lower() != 'ok':
-            print(f'Got eeprom info with bad statuses: {eeprom_info}')
-            return False
-        return True
-
-    def get_part_number(self):
-        if not self.get_eeprom_id():
-            print(f"Component {self.name} doesn't have eeprom id. Will not get part number")
-            return None
-
-        eeprom_info = self.get_eeprom_info()
-        if False == self._is_bmc_eeprom_content_valid(eeprom_info):
-            print(f"Can't get part number for BMC because eeprom is not valid")
-            return None
-        else:
-            return eeprom_info.get('PartNumber')
-
-    def get_model(self):
-        if not self.get_eeprom_id():
-            print(f"Component {self.name} doesn't have eeprom id. Will not get model")
-            return None
-
-        eeprom_info = self.get_eeprom_info()
-        if False == self._is_bmc_eeprom_content_valid(eeprom_info):
-            print(f"Can't get model for BMC because eeprom is not valid")
-            return None
-        else:
-            return eeprom_info.get('Model')
-
-    def get_serial_number(self):
-        if not self.get_eeprom_id():
-            print(f"Component {self.name} doesn't have eeprom id. Will not get serial number")
-            return None
-
-        eeprom_info = self.get_eeprom_info()
-        if False == self._is_bmc_eeprom_content_valid(eeprom_info):
-            print(f"Can't get serial number for BMC because eeprom is not valid")
-            return None
-        else:
-            return eeprom_info.get('SerialNumber')
+        return self.bmc.get_version()
     
     # TODO(BMC): Add get_firmware_update_notification if power cycle is needed
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/redfish_client.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/redfish_client.py
@@ -555,7 +555,7 @@ class RedfishClient:
     Example of Payload:
         "Payload": {
             "HttpHeaders": [
-            "Host: 10.0.1.1",
+            "Host: 169.254.0.1",
             "User-Agent: curl/7.74.0",
             "Accept: */*",
             "Content-Length: 76",

--- a/platform/mellanox/mlnx-platform-api/tests/mock_parsed_bmc_eeprom_dict
+++ b/platform/mellanox/mlnx-platform-api/tests/mock_parsed_bmc_eeprom_dict
@@ -1,0 +1,14 @@
+{
+	"ChassisType": "Module",
+	"Health": "OK",
+	"HealthRollup": "OK",
+	"Id": "BMC_eeprom",
+	"Location": "{'PartLocation': {'LocationType': 'Embedded'}}",
+	"Manufacturer": "NVIDIA",
+	"Model": "P3809",
+	"Name": "BMC_eeprom",
+	"PartNumber": "692-13809-3404-000",
+	"PowerState": "On",
+	"SerialNumber": "1320725102601",
+	"State": "Enabled"
+}

--- a/platform/mellanox/mlnx-platform-api/tests/test_bmc.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_bmc.py
@@ -1,0 +1,160 @@
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import pytest
+import sys
+import json
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, modules_path)
+
+from sonic_platform.bmc import BMC
+from sonic_platform.redfish_client import RedfishClient
+from sonic_py_common import device_info
+from sonic_platform import utils
+
+
+class MockBMCComponent:
+    def get_firmware_id(self):
+        return 'MGX_FW_BMC_0'
+
+    def get_name(self):
+        return 'BMC'
+
+
+class TestBMC:
+    @mock.patch('sonic_platform.bmc.device_info.get_bmc_data', \
+                mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
+    @mock.patch('sonic_platform.bmc.BMC.get_login_password', mock.MagicMock(return_value=''))
+    @mock.patch('sonic_platform.bmc.BMC.get_eeprom_id')
+    @mock.patch('sonic_platform.bmc.BMC.get_eeprom_info')
+    def test_bmc_get_eeprom(self, mock_get_eeprom_info, mock_get_eeprom_id):
+        """Test get_eeprom method with successful EEPROM retrieval"""
+        eeprom_dict_file_path = os.path.join(test_path, 'mock_parsed_bmc_eeprom_dict')
+        with open(eeprom_dict_file_path, 'r') as f:
+            data = f.read()
+            expected_eeprom_data = json.loads(data)
+        
+        mock_get_eeprom_id.return_value = 'BMC_eeprom'
+        mock_get_eeprom_info.return_value = (RedfishClient.ERR_CODE_OK, expected_eeprom_data)
+
+        bmc = BMC.get_instance()
+        result = bmc.get_eeprom()
+
+        assert result == expected_eeprom_data
+        mock_get_eeprom_id.assert_called_once()
+        mock_get_eeprom_info.assert_called_once_with('BMC_eeprom')
+
+    @mock.patch('sonic_platform.bmc.device_info.get_bmc_data', \
+                mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
+    @mock.patch('sonic_platform.bmc.BMC.get_login_password', mock.MagicMock(return_value=''))
+    @mock.patch('sonic_platform.bmc.BMC.get_component_attr')
+    @mock.patch('sonic_platform.bmc.BMC.get_firmware_version')
+    def test_bmc_get_version(self, mock_get_firmware_version, mock_get_component_attr):
+        """Test get_version method with successful version retrieval"""
+        expected_version = '88.0002.1252'
+        mock_get_component_attr.return_value = 'MGX_FW_BMC_0'
+        mock_get_firmware_version.return_value = (RedfishClient.ERR_CODE_OK, expected_version)
+
+        bmc = BMC.get_instance()
+        result = bmc.get_version()
+
+        assert result == expected_version
+        mock_get_component_attr.assert_called_once_with('BMC', 'id')
+        mock_get_firmware_version.assert_called_once_with('MGX_FW_BMC_0')
+
+    @mock.patch('sonic_platform.bmc.device_info.get_bmc_data', \
+                mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
+    @mock.patch('sonic_platform.bmc.BMC.get_login_password', mock.MagicMock(return_value=''))
+    @mock.patch('sonic_platform.bmc.BMC.login')
+    @mock.patch('sonic_platform.bmc.BMC.change_login_password')
+    @mock.patch('sonic_platform.bmc.BMC.logout')
+    def test_bmc_reset_password(self, mock_logout, mock_change_password, mock_login):
+        """Test reset_password method with successful password reset"""
+        mock_login.return_value = RedfishClient.ERR_CODE_OK
+        mock_change_password.return_value = (RedfishClient.ERR_CODE_OK, 'Password changed successfully')
+        mock_logout.return_value = RedfishClient.ERR_CODE_OK
+
+        bmc = BMC.get_instance()
+        ret, msg = bmc.reset_password()
+
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert msg == 'Password changed successfully'
+        mock_login.assert_called_once()
+        mock_change_password.assert_called_once_with(BMC.ROOT_ACCOUNT_DEFAULT_PASSWORD, BMC.ROOT_ACCOUNT)
+        mock_logout.assert_called_once()
+
+    @mock.patch('sonic_platform.bmc.device_info.get_bmc_data', \
+                mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
+    @mock.patch('sonic_platform.bmc.BMC.get_login_password', mock.MagicMock(return_value=''))
+    @mock.patch('sonic_platform.redfish_client.RedfishClient.redfish_api_trigger_bmc_debug_log_dump')
+    def test_bmc_trigger_bmc_debug_log_dump(self, mock_trigger_debug_log_dump):
+
+        expected_msg = 'Success'
+        task_id = '0'
+        mock_trigger_debug_log_dump.return_value = (RedfishClient.ERR_CODE_OK, (task_id, expected_msg))
+
+        bmc = BMC.get_instance()
+        (ret, (ret_task_id, msg)) = bmc.trigger_bmc_debug_log_dump()
+
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert msg == expected_msg
+        assert task_id == ret_task_id
+
+    @mock.patch('sonic_platform.bmc.device_info.get_bmc_data', \
+                mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
+    @mock.patch('sonic_platform.bmc.BMC.get_login_password', mock.MagicMock(return_value=''))
+    @mock.patch('sonic_platform.redfish_client.RedfishClient.redfish_api_get_bmc_debug_log_dump')
+    def test_bmc_get_bmc_debug_log_dump(self, mock_get_debug_log_dump):
+
+        expected_msg = 'Success'
+        mock_get_debug_log_dump.return_value = (RedfishClient.ERR_CODE_OK, expected_msg)
+
+        bmc = BMC.get_instance()
+        (ret, msg) = bmc.get_bmc_debug_log_dump('0', '/tmp', 'file.txt')
+
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert msg == expected_msg
+
+    @mock.patch('sonic_platform.bmc.BMC.get_component_list', \
+        mock.MagicMock(return_value=[MockBMCComponent()]))
+    @mock.patch('sonic_platform.bmc.device_info.get_bmc_data', \
+                mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
+    @mock.patch('sonic_platform.bmc.BMC.get_login_password', mock.MagicMock(return_value=''))
+    @mock.patch('sonic_platform.component.ComponentBMC._check_file_validity', \
+                mock.MagicMock(return_value=True))
+    @mock.patch('sonic_platform.redfish_client.RedfishClient.redfish_api_update_firmware')
+    @mock.patch('sonic_platform.redfish_client.RedfishClient.login')
+    def test_bmc_update_firmware(self, mock_login, mock_update_fw):
+        """Test update_firmware method with successful update without force"""
+        component_id = 'MGX_FW_BMC_0'
+        mock_login.return_value = RedfishClient.ERR_CODE_OK
+        mock_update_fw.return_value = (RedfishClient.ERR_CODE_OK, 'Update successful', [component_id], [])
+
+        bmc = BMC.get_instance()
+        ret, (msg, updated) = bmc.update_firmware('fake_image.fwpkg')
+
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert updated == True
+        assert msg == 'Update successful'
+        mock_update_fw.assert_called_once_with('fake_image.fwpkg', None, False, 1800, None)

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,13 +39,25 @@ from sonic_platform.component import ComponentONIE,       \
                                      ComponenetFPGADPU,   \
                                      MPFAManager,         \
                                      ONIEUpdater,         \
+                                     ComponentBMCObj,     \
+                                     ComponentBMC,        \
                                      Component
+from sonic_platform.bmc import BMC
 from sonic_platform_base.component_base import FW_AUTO_INSTALLED,      \
                                                FW_AUTO_UPDATED,        \
                                                FW_AUTO_SCHEDULED,      \
                                                FW_AUTO_ERR_BOOT_TYPE,  \
                                                FW_AUTO_ERR_IMAGE,      \
                                                FW_AUTO_ERR_UNKNOWN
+
+from sonic_platform.redfish_client import RedfishClient
+
+class MockBMCComponent:
+    def get_firmware_id(self):
+        return 'MGX_FW_BMC_0'
+
+    def get_name(self):
+        return 'BMC'
 
 
 class TestComponent:
@@ -564,3 +576,24 @@ class TestComponent:
         assert c._check_file_validity(os.path.abspath(__file__))
         c.image_ext_name = '.txt'
         assert not c._check_file_validity(os.path.abspath(__file__))
+    
+    @mock.patch('sonic_platform.bmc.BMC.get_component_list', \
+        mock.MagicMock(return_value=[MockBMCComponent()]))
+    @mock.patch('sonic_platform.bmc.device_info.get_bmc_data', \
+                mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
+    @mock.patch('sonic_platform.bmc.BMC.get_login_password', mock.MagicMock(return_value=''))
+    @mock.patch('sonic_platform.component.ComponentBMC._check_file_validity', \
+                mock.MagicMock(return_value=True))
+    @mock.patch('sonic_platform.redfish_client.RedfishClient.redfish_api_update_firmware')
+    @mock.patch('sonic_platform.redfish_client.RedfishClient.login')
+    def test_bmc_update_firmware(self, mock_login, mock_update_fw):
+        mock_login.return_value = RedfishClient.ERR_CODE_OK
+        mock_update_fw.return_value = (RedfishClient.ERR_CODE_OK, '', ['MGX_FW_BMC_0'], [])
+        attrs = {
+            'id': 'MGX_FW_BMC_0',
+            'eeprom_id': 'BMC_eeprom'
+        }
+        component = ComponentBMC('BMC', attrs)
+        ret, (error_msg, updated) = component.install_firmware('fake_image.fwpkg')
+        assert ret == True
+        assert updated == True


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

