### PR TITLE
Refactor fw upgrade

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -930,29 +930,22 @@ class ComponentBMCObj(Component):
     def get_eeprom_id(self):
         return self.eeprom_id
 
-    def install_firmware(self, image_path, allow_reboot=True, force_update=False, progress_callback=None):
+    def install_firmware(self, image_path):
         if not self._check_file_validity(image_path):
             return (False, ('Invalid firmware image path', False))
-
         print('Starting {} firmware update, path={}'.format(self.get_firmware_id(), image_path))
         ret = 0
         error_msg = ''
-        updated = False
 
         try:
-            ret, (error_msg, updated) = self.bmc.update_firmware(image_path,
-                                                                 [],
-                                                                 force_update,
-                                                                 progress_callback)
+            ret, error_msg = self.bmc.update_firmware(image_path)
         except Exception as e:
             error_trace = traceback.format_exc()
             print(str(e))
             print(error_trace)
             raise
 
-        if (ret == 0):
-            if not updated:
-                print('No BMC firmware update')
+        if ret == 0:
             print('Successfully upgraded BMC firmware')
             # TODO(BMC): Check if power cycle is required for apply the installation
             return True

--- a/platform/mellanox/mlnx-platform-api/tests/test_bmc.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_bmc.py
@@ -145,9 +145,8 @@ class TestBMC:
     @mock.patch('sonic_platform.redfish_client.RedfishClient.login')
     def test_bmc_update_firmware(self, mock_login, mock_update_fw):
         """Test update_firmware method with successful update without force"""
-        component_id = 'MGX_FW_BMC_0'
         mock_login.return_value = RedfishClient.ERR_CODE_OK
-        mock_update_fw.return_value = (RedfishClient.ERR_CODE_OK, 'Update successful', [component_id], [])
+        mock_update_fw.return_value = (RedfishClient.ERR_CODE_OK, 'Update successful')
 
         bmc = BMC.get_instance()
         ret, (msg, updated) = bmc.update_firmware('fake_image.fwpkg')

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -588,7 +588,7 @@ class TestComponent:
     @mock.patch('sonic_platform.redfish_client.RedfishClient.login')
     def test_bmc_update_firmware(self, mock_login, mock_update_fw):
         mock_login.return_value = RedfishClient.ERR_CODE_OK
-        mock_update_fw.return_value = (RedfishClient.ERR_CODE_OK, '', ['MGX_FW_BMC_0'], [])
+        mock_update_fw.return_value = (RedfishClient.ERR_CODE_OK, '')
         attrs = {
             'id': 'MGX_FW_BMC_0',
             'eeprom_id': 'BMC_eeprom'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

