### PR TITLE
Disable PFC WD by default on init_config.json for SN5640

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -1,10 +1,11 @@
+{%- set configured_platform = CONFIGURED_PLATFORM | default('') -%}
 {
     "DEVICE_METADATA": {
         "localhost": {
             "buffer_model": {% if default_buffer_model == "dynamic" %}"dynamic"{% else %}"traditional"{% endif %},
             {%- if include_p4rt == "y" %}"synchronous_mode":"enable",{% endif %}
             "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %},
-            "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %},
+            "default_pfcwd_status": {% if configured_platform == "x86_64-nvidia_sn5640-r0" %}"disable"{% elif enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %},
             "timezone": "UTC"
         }
     },


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Generating configuration using minigraph, when PFC WD is enabled, on system with more than 448 ports, 
will lead to validation Error message since the allowed range for PFC WD POLL_INTERVAL (100..3000) will be violated.

This will happen if "enable_pfcwd_on_start" is set to "y". This configuation is taken from ini_config.json.

This PR set this flag to "disable" for SN5640 system in which PFC WD is not relevant for it as it doesn't work with lossless mode.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Set "enable_pfcwd_on_start" to "disable" in init_config.json file for sn5640 NVIDIA platform

#### How to verify it
Generate configuration using minigraph for 512 interfaces hwSKU and make sure no Error message is triggered.  
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

